### PR TITLE
Update pyodide from v0.22.0 to v0.23.3

### DIFF
--- a/src/workers/python-console-worker.ts
+++ b/src/workers/python-console-worker.ts
@@ -1,4 +1,4 @@
-importScripts('https://cdn.jsdelivr.net/pyodide/v0.22.0/full/pyodide.js')
+importScripts('https://cdn.jsdelivr.net/pyodide/v0.23.3/full/pyodide.js')
 
 interface Pyodide {
   loadPackage: (packages: string[]) => Promise<void>

--- a/src/workers/python-worker.ts
+++ b/src/workers/python-worker.ts
@@ -1,4 +1,4 @@
-importScripts('https://cdn.jsdelivr.net/pyodide/v0.22.0/full/pyodide.js')
+importScripts('https://cdn.jsdelivr.net/pyodide/v0.23.3/full/pyodide.js')
 
 interface Pyodide {
   loadPackage: (packages: string[]) => Promise<void>


### PR DESCRIPTION
I see there is a draft PR that switches to the NPM package, but if that's a ways off we might want to update pyodide in the meantime.