### PR TITLE
Upgrade pyodide version to v0.25.1

### DIFF
--- a/src/workers/python-console-worker.ts
+++ b/src/workers/python-console-worker.ts
@@ -1,4 +1,4 @@
-importScripts('https://cdn.jsdelivr.net/pyodide/v0.23.4/full/pyodide.js')
+importScripts('https://cdn.jsdelivr.net/pyodide/v0.25.1/full/pyodide.js')
 
 interface Pyodide {
   loadPackage: (packages: string[]) => Promise<void>

--- a/src/workers/python-worker.ts
+++ b/src/workers/python-worker.ts
@@ -1,4 +1,4 @@
-importScripts('https://cdn.jsdelivr.net/pyodide/v0.23.4/full/pyodide.js')
+importScripts('https://cdn.jsdelivr.net/pyodide/v0.25.1/full/pyodide.js')
 
 interface Pyodide {
   loadPackage: (packages: string[]) => Promise<void>


### PR DESCRIPTION
v0.25.1 is the latest stable version(v0.26 will be released soon), we can upgrade the pyodide to the current stable version.