### PR TITLE
fix safari not updating state correctly

### DIFF
--- a/src/hooks/usePythonConsole.ts
+++ b/src/hooks/usePythonConsole.ts
@@ -26,6 +26,7 @@ export default function usePythonConsole(props?: UsePythonConsoleProps) {
   const [banner, setBanner] = useState<string | undefined>()
   const [consoleState, setConsoleState] = useState<ConsoleState>()
   const [isRunning, setIsRunning] = useState(false)
+  const [output, setOutput] = useState<string[]>([])
   const [stdout, setStdout] = useState('')
   const [stderr, setStderr] = useState('')
   const [pendingCode, setPendingCode] = useState<string | undefined>()
@@ -72,6 +73,13 @@ export default function usePythonConsole(props?: UsePythonConsoleProps) {
     }
   }, [])
 
+  // Immediately set stdout upon receiving new input
+  useEffect(() => {
+    if (output.length > 0 && !isRunning) {
+      setStdout(output.join(''))
+    }
+  }, [output, isRunning])
+
   const allPackages = useMemo(() => {
     const official = [
       ...new Set([
@@ -104,7 +112,7 @@ export default function usePythonConsole(props?: UsePythonConsoleProps) {
               if (suppressedMessages.includes(msg)) {
                 return
               }
-              setStdout(msg)
+              setOutput((prev) => [...prev, msg])
             }),
             proxy(({ id, version, banner }) => {
               setRunnerId(id)
@@ -150,6 +158,7 @@ del sys
   const runPython = useCallback(
     async (code: string) => {
       // Clear stdout and stderr
+      setOutput([])
       setStdout('')
       setStderr('')
 


### PR DESCRIPTION
There is an issue in react facebook/react/issues/26713 where react skips renders in Safari for years. 

In the `usePythonConsole` hook, the function `runPython` will cause rerender twice: the script result and `"\n"`. For example, `runPython("print('hi!')")` will update the state of `stdout` twice: `"hi!"` and `"\n"`. The issue above make the components only rerender in the last `setStdout`: `"\n"`. 

This pull request propose to fix it by getting the list of output stream in to `output` state and then join them as `stdout` after the program is not running. 