### PR TITLE
Feature Update

### DIFF
--- a/src/hooks/usePythonConsole.ts
+++ b/src/hooks/usePythonConsole.ts
@@ -26,6 +26,7 @@ export default function usePythonConsole(props?: UsePythonConsoleProps) {
   const [banner, setBanner] = useState<string | undefined>()
   const [consoleState, setConsoleState] = useState<ConsoleState>()
   const [isRunning, setIsRunning] = useState(false)
+  const [output, setOutput] = useState<string[]>([])
   const [stdout, setStdout] = useState('')
   const [stderr, setStderr] = useState('')
   const [pendingCode, setPendingCode] = useState<string | undefined>()
@@ -72,6 +73,13 @@ export default function usePythonConsole(props?: UsePythonConsoleProps) {
     }
   }, [])
 
+  // Immediately set stdout upon receiving new input
+  useEffect(() => {
+    if (output.length > 0 && !isRunning) {
+      setStdout(output.join(''))
+    }
+  }, [output, isRunning])
+
   const allPackages = useMemo(() => {
     const official = [
       ...new Set([
@@ -104,7 +112,7 @@ export default function usePythonConsole(props?: UsePythonConsoleProps) {
               if (suppressedMessages.includes(msg)) {
                 return
               }
-              setStdout(msg)
+              setOutput((prev) => [...prev, msg])
             }),
             proxy(({ id, version, banner }) => {
               setRunnerId(id)
@@ -150,6 +158,7 @@ del sys
   const runPython = useCallback(
     async (code: string) => {
       // Clear stdout and stderr
+      setOutput([])
       setStdout('')
       setStderr('')
 

--- a/src/hooks/usePythonConsole.ts
+++ b/src/hooks/usePythonConsole.ts
@@ -18,7 +18,7 @@ interface UsePythonConsoleProps {
   packages?: Packages
 }
 
-export default function usePythonConsole(props?: UsePythonConsoleProps) {
+function usePython(props?: UsePythonConsoleProps) {
   const { packages = {} } = props ?? {}
 
   const [runnerId, setRunnerId] = useState<string>()
@@ -241,6 +241,7 @@ del sys
   return {
     runPython,
     stdout,
+    output,
     stderr,
     isLoading,
     isReady,
@@ -257,5 +258,32 @@ del sys
     isAwaitingInput,
     sendInput: sendUserInput,
     prompt: runnerId ? getPrompt(runnerId) : ''
+  }
+}
+
+export default function usePythonConsole(props?: UsePythonConsoleProps) {
+  const { stderr, stdout, runPython, consoleState, ...pyconsole } =
+    usePython(props)
+  const [output, setOutput] = useState([''])
+  function getPrompt() {
+    return consoleState === ConsoleState.incomplete ? '... ' : '>>> '
+  }
+
+  function run(input: string) {
+    setOutput((prev) => [...prev, getPrompt() + input + '\n'])
+    runPython(input)
+  }
+
+  useEffect(() => {
+    if (stdout === pyconsole.output.join('')) {
+      setOutput((prev) => [...prev, stdout, stderr ? stderr + '\n' : ''])
+    }
+  }, [stdout, pyconsole.output, stderr])
+
+  return {
+    ...pyconsole,
+    output,
+    run,
+    getPrompt
   }
 }

--- a/src/types/Runner.ts
+++ b/src/types/Runner.ts
@@ -1,3 +1,5 @@
+import { TypedArray } from 'pyodide'
+
 export interface Runner {
   init: (
     stdout: (msg: string) => void,
@@ -11,6 +13,7 @@ export interface Runner {
       banner?: string
     }) => void,
     mode: 'standard' | 'console',
+    interruptBuffer: TypedArray,
     packages?: string[][]
   ) => Promise<void>
   interruptExecution: () => void

--- a/src/workers/python-worker.ts
+++ b/src/workers/python-worker.ts
@@ -1,7 +1,11 @@
 importScripts('https://cdn.jsdelivr.net/pyodide/v0.26.2/full/pyodide.js')
 
 import { expose } from 'comlink'
-import { loadPyodide as loadPyodideType, PyodideInterface } from 'pyodide'
+import {
+  loadPyodide as loadPyodideType,
+  PyodideInterface,
+  TypedArray
+} from 'pyodide'
 
 declare global {
   interface Window {
@@ -72,9 +76,12 @@ const python = {
       banner?: string
     }) => void,
     mode: 'standard' | 'console',
+    interruptBuffer: TypedArray,
     packages?: string[][]
   ) {
     self.pyodide = await self.loadPyodide({ stdout })
+
+    self.pyodide.setInterruptBuffer(interruptBuffer)
 
     // Enable debug mode
     // self.pyodide.setDebug(true)
@@ -98,11 +105,11 @@ const python = {
 
     const initCode = `
 import sys
-import pyodide_http
+#import pyodide_http
 
 sys.tracebacklimit = 0
 
-pyodide_http.patch_all()
+#pyodide_http.patch_all()
 `
     await self.pyodide.runPythonAsync(initCode)
 

--- a/src/workers/python-worker.ts
+++ b/src/workers/python-worker.ts
@@ -34,7 +34,9 @@ const reactPyModule = {
     // Synchronous request to be intercepted by service worker
     request.open(
       'GET',
-      `/react-py-get-input/?id=${id}&prompt=${encodeURIComponent(prompt)}`,
+      `${
+        location.origin
+      }/react-py-get-input/?id=${id}&prompt=${encodeURIComponent(prompt)}`,
       false
     )
     request.send(null)


### PR DESCRIPTION
# About this pull request
There are several bugs or enhancement in the hook
1. Invalid url in `getInput()` in next.js project for Chromium (SyntaxError: The string did not match the expected pattern for Safari)
2. We can handle the output for users and the output stream should be `stdout line 1` -> `stdout line 2` -> ... -> `stdout line n` -> `stderr`.
3. Timeout will terminate the workers.

## Fixing the bug in 1.
1. Adding workerUrl in props for the PythonProvider in next.js. This allowes the provider use `public/react-py-sw.js` for the service-worker; 
2. use `windows.location.origin` (`location.origin` for `python-worker.ts`) as the base url of the url in `PythonProvider`.
```js
<PythonProvider workerUrl="react-py-sw.js">
    {children}
</PythonProvider>
```
## Enhancing the output
For example, the python script 
```py
for i in range(10):
  print(i)
  if i == 2:
    raise ValueError()
```
should results in 
```
0
1
2
Traceback (most recent call last):
  File "<console>", line 4, in <module>
ValueError
```
but the code in the docs will leads because the stdout is still updating the results.
```
Traceback (most recent call last):
  File "<console>", line 4, in <module>
ValueError
0
1
2
```

Due to the rendering bug in Safari. By observation, updating output array in stdout stream will end faster than updating the stdout. We can wait until the stdout stream is ended which is `stdout === output.join('')` and add the `stderr` at the end.

## Fix 3.
I added the shared arrary buffer based on https://pyodide.org/en/stable/usage/keyboard-interrupts.html. However, github pages does allowed to add custom headers so i can update the docs because of that

## TODO
- [x] fix input error for next.js
- [x] handle the outputs
- [x] show stderr after appending the previous stdout 
- [x] fix 3.
- [ ] ~update docs~
- [x] test in other browsers (test in safari, chrome, firefox)